### PR TITLE
added specific version of @types/geojson as dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "@angular/language-service": "~8.2.12",
     "@types/bootstrap": "~4.1.2",
     "@types/d3": "^5.7.2",
+    "@types/geojson": "7946.0.8",
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",


### PR DESCRIPTION
The newest version (7946.0.10) of the geojson library has an error.
To use geojson with typescript we need to manually specify the last working version.